### PR TITLE
Allow Math::BigInt to be used for Epoch

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ author  = Olaf Alders <oalders@maxmind.com>
 license = Artistic_2_0
 copyright_holder = MaxMind, Inc.
 
-version = 0.031003
+version = 0.040000
 
 [NextRelease]
 format = %-8v %{yyyy-MM-dd}d

--- a/lib/MaxMind/DB/Metadata.pm
+++ b/lib/MaxMind/DB/Metadata.pm
@@ -4,8 +4,6 @@ use strict;
 use warnings;
 use namespace::autoclean;
 
-use Math::Int128;
-
 use Moo;
 use MaxMind::DB::Types qw( ArrayRefOfStr Epoch HashRefOfStr Int Str );
 use MooX::StrictConstructor;

--- a/lib/MaxMind/DB/Types.pm
+++ b/lib/MaxMind/DB/Types.pm
@@ -69,10 +69,12 @@ our @EXPORT_OK = qw(
         q{
 (
     defined $_[0] && ( ( !ref $_[0] && $_[0] =~ /^[0-9]+$/ )
-        || ( Scalar::Util::blessed( $_[0] ) && $_[0]->isa('Math::UInt128') ) )
+        || ( Scalar::Util::blessed( $_[0] )
+            && ( $_[0]->isa('Math::UInt128') || $_[0]->isa('Math::BigInt') ) )
+        )
     )
     or MaxMind::DB::Types::_confess(
-    '%s is not an integer or a Math::UInt128 object',
+    '%s is not an integer, a Math::UInt128 object, or a Math::BigInt object',
     $_[0]
     );
 }


### PR DESCRIPTION
Needed to allow the PP reader to use Math::BigInt for large integers.