### PR TITLE
Allow Int to be a Math::BigInt

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Validation on the Int type used in the Metadata class has been loosened,
+  which should fix MaxMind::DB::Reader test failures on some platforms.
+
+
 0.040000 2015-04-29
 
 - Use Math::BigInt rather than Math::Int128 as part of working towards making

--- a/lib/MaxMind/DB/Types.pm
+++ b/lib/MaxMind/DB/Types.pm
@@ -84,6 +84,8 @@ our @EXPORT_OK = qw(
     );
 
     sub Epoch () { $t }
+
+    sub Int () { $t }
 }
 
 {
@@ -133,20 +135,6 @@ our @EXPORT_OK = qw(
     );
 
     sub HashRefOfStr () { $t }
-}
-
-{
-    my $t = quote_sub(
-        q{
-( defined $_[0] && !ref $_[0] && $_[0] =~ /^[0-9]+$/ )
-    or MaxMind::DB::Types::_confess(
-    '%s is not a valid integer',
-    $_[0]
-    );
-}
-    );
-
-    sub Int () { $t }
 }
 
 {

--- a/t/MaxMind/DB/Metadata.t
+++ b/t/MaxMind/DB/Metadata.t
@@ -3,9 +3,10 @@ use warnings;
 
 use Test::More;
 
+use Math::BigInt ();
 use MaxMind::DB::Metadata;
 
-my $metadata = MaxMind::DB::Metadata->new(
+my %args = (
     binary_format_major_version => 1,
     binary_format_minor_version => 1,
     build_epoch                 => time(),
@@ -16,6 +17,19 @@ my $metadata = MaxMind::DB::Metadata->new(
     record_size                 => 32,
 );
 
-ok( $metadata, 'code compiles' );
+{
+    my $metadata = MaxMind::DB::Metadata->new(%args);
+
+    ok( $metadata, 'code compiles' );
+}
+
+{
+    my $metadata = MaxMind::DB::Metadata->new(
+        %args,
+        binary_format_major_version => Math::BigInt->bone,
+    );
+
+    ok( $metadata, 'Math::BigInt works as Int in Metadata' );
+}
 
 done_testing();


### PR DESCRIPTION
This should fix the Windows reader test failures.